### PR TITLE
Expand P2P demo with wallet and task storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+p2papp/data/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,84 @@
-# test2
+# Secure P2P Demo
+
+This repo contains a tiny prototype of a privacy first peer to peer app.  It
+includes a command line interface demonstrating phone pairing, encrypted
+messaging and a local bounty board.  The code uses an ephemeral X25519 handshake
+with AES‑GCM for all traffic.  Private keys and optional wallet seeds are stored
+locally and can be protected with a passphrase which represents the biometric
+check on the phone.
+
+## Requirements
+
+* Python 3.11+
+* `cryptography` and `websockets`
+
+Install dependencies with:
+
+```bash
+pip install cryptography websockets
+```
+
+## Usage
+
+### Pair devices
+
+Generate a key pair the first time you run the app:
+
+```bash
+python3 -m p2papp.cli pair
+```
+
+### Run a node
+
+Start the local server:
+
+```bash
+python3 -m p2papp.cli serve
+```
+
+Send an encrypted message from another terminal or machine:
+
+```bash
+python3 -m p2papp.cli send ws://HOST:8765 "hello"
+```
+
+### Wallet
+
+Create wallet seeds (shown once and stored encrypted):
+
+```bash
+python3 -m p2papp.cli wallet create
+```
+
+View stored seeds later with `wallet show`.
+
+### Tasks
+
+Add a local bounty/task:
+
+```bash
+python3 -m p2papp.cli addtask "Fix bug" "Need help" 1ETH 5
+```
+
+List stored tasks:
+
+```bash
+python3 -m p2papp.cli listtasks
+```
+
+All task data is stored locally in `p2papp/data/` encrypted at rest.  This keeps
+private details on your device while still enabling peer discovery when the node
+is extended to broadcast listings.
+
+## Project Overview
+
+* **Peer to peer mesh** – every instance can act as client and server.
+* **End to end encryption** – Noise‑like handshake using X25519 and AES‑GCM.
+* **Phone pairing** – keys live locally and are unlocked via passphrase.
+* **Self custody wallets** – optional Bitcoin and Ethereum seeds stored
+  encrypted.
+* **Local discovery board** – tasks are saved locally and can later be shared
+  with nearby peers.
+
+The current code is intentionally small but forms the basis of the larger design
+outlined in the project description.

--- a/p2papp/__init__.py
+++ b/p2papp/__init__.py
@@ -1,0 +1,1 @@
+"""Minimal secure peer-to-peer toolkit."""

--- a/p2papp/cli.py
+++ b/p2papp/cli.py
@@ -1,0 +1,69 @@
+import argparse
+import asyncio
+from getpass import getpass
+from .node import P2PNode
+from . import keys, wallet, storage
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple P2P App")
+    sub = parser.add_subparsers(dest="cmd")
+
+    sub.add_parser("serve")
+
+    send = sub.add_parser("send")
+    send.add_argument("uri")
+    send.add_argument("message")
+
+    sub.add_parser("pair")
+
+    wgen = sub.add_parser("wallet")
+    wgen.add_argument("action", choices=["create", "show"])
+
+    addt = sub.add_parser("addtask")
+    addt.add_argument("title")
+    addt.add_argument("description")
+    addt.add_argument("reward")
+    addt.add_argument("radius", type=int)
+
+    sub.add_parser("listtasks")
+
+    args = parser.parse_args()
+
+    passphrase_in = getpass("Biometric unlock: ") or None
+    passphrase = passphrase_in.encode() if passphrase_in else None
+
+    if args.cmd == "pair":
+        keys.generate_keys(passphrase)
+        print("Keys generated")
+        return
+
+    node = P2PNode(nickname="anon", passphrase=passphrase)
+
+    if args.cmd == "serve":
+        asyncio.run(node.start_server())
+    elif args.cmd == "send":
+        payload = {"msg": args.message}
+        asyncio.run(node.connect_and_send(args.uri, payload))
+    elif args.cmd == "wallet":
+        if args.action == "create":
+            btc, eth = wallet.generate_wallet(passphrase)
+            print("Bitcoin seed:", btc)
+            print("Ethereum seed:", eth)
+        else:
+            btc, eth = wallet.load_wallet(passphrase)
+            print("Bitcoin seed:", btc)
+            print("Ethereum seed:", eth)
+    elif args.cmd == "addtask":
+        storage.add_task(args.title, args.description, args.reward, args.radius, passphrase)
+        print("Task saved")
+    elif args.cmd == "listtasks":
+        tasks = storage.load_tasks(passphrase)
+        for t in tasks:
+            print(f"{t['title']} - {t['reward']} within {t['radius']}km")
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/p2papp/keys.py
+++ b/p2papp/keys.py
@@ -1,0 +1,36 @@
+import os
+from pathlib import Path
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.hazmat.primitives import serialization
+
+KEY_DIR = Path(__file__).resolve().parent / 'data'
+PRIVATE_KEY_FILE = KEY_DIR / 'private_key.pem'
+PUBLIC_KEY_FILE = KEY_DIR / 'public_key.pem'
+
+
+def generate_keys(passphrase: bytes | None = None) -> None:
+    """Generate an Ed25519 key pair and store it with restrictive permissions."""
+    KEY_DIR.mkdir(exist_ok=True)
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    priv_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.BestAvailableEncryption(passphrase) if passphrase else serialization.NoEncryption(),
+    )
+    pub_bytes = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    PRIVATE_KEY_FILE.write_bytes(priv_bytes)
+    os.chmod(PRIVATE_KEY_FILE, 0o600)
+    PUBLIC_KEY_FILE.write_bytes(pub_bytes)
+
+
+def load_private_key(passphrase: bytes | None = None):
+    data = PRIVATE_KEY_FILE.read_bytes()
+    return serialization.load_pem_private_key(data, password=passphrase)
+
+
+def load_public_key():
+    data = PUBLIC_KEY_FILE.read_bytes()
+    return serialization.load_pem_public_key(data)

--- a/p2papp/node.py
+++ b/p2papp/node.py
@@ -1,0 +1,69 @@
+import asyncio
+import json
+import os
+from websockets import serve
+from websockets.client import connect
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.asymmetric import x25519
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from . import keys
+
+
+class P2PNode:
+    def __init__(self, nickname: str, passphrase: bytes | None = None):
+        self.nickname = nickname
+        if not keys.PRIVATE_KEY_FILE.exists():
+            keys.generate_keys(passphrase)
+        self.private_key: Ed25519PrivateKey = keys.load_private_key(passphrase)
+        self.public_key = self.private_key.public_key()
+
+    async def handler(self, websocket):
+        await self.perform_handshake(websocket, initiator=False)
+        async for raw in websocket:
+            nonce_hex, ct_hex = raw.split(":", 1)
+            plaintext = self.aesgcm.decrypt(bytes.fromhex(nonce_hex), bytes.fromhex(ct_hex), None)
+            data = json.loads(plaintext.decode())
+            print(f"Received: {data}")
+
+    async def start_server(self, host="0.0.0.0", port=8765):
+        async with serve(self.handler, host, port):
+            print(f"Listening on {host}:{port}")
+            await asyncio.Future()
+
+    async def connect_and_send(self, uri: str, payload: dict):
+        async with connect(uri) as websocket:
+            await self.perform_handshake(websocket, initiator=True)
+            plaintext = json.dumps(payload).encode()
+            nonce = os.urandom(12)
+            ct = self.aesgcm.encrypt(nonce, plaintext, None)
+            await websocket.send(f"{nonce.hex()}:{ct.hex()}")
+
+    async def perform_handshake(self, websocket, initiator: bool):
+        """Establish a shared AES key using an ephemeral X25519 exchange."""
+        my_identity = self.public_key.public_bytes(
+            serialization.Encoding.Raw,
+            serialization.PublicFormat.Raw,
+        )
+        eph_priv = x25519.X25519PrivateKey.generate()
+        eph_pub = eph_priv.public_key().public_bytes(
+            serialization.Encoding.Raw,
+            serialization.PublicFormat.Raw,
+        )
+        if initiator:
+            await websocket.send(json.dumps({"id": my_identity.hex(), "eph": eph_pub.hex()}))
+            msg = json.loads(await websocket.recv())
+        else:
+            msg = json.loads(await websocket.recv())
+            await websocket.send(json.dumps({"id": my_identity.hex(), "eph": eph_pub.hex()}))
+
+        peer_id = bytes.fromhex(msg["id"])
+        peer_eph = x25519.X25519PublicKey.from_public_bytes(bytes.fromhex(msg["eph"]))
+        shared = eph_priv.exchange(peer_eph)
+
+        hkdf = HKDF(algorithm=SHA256(), length=32, salt=None, info=b"p2p")
+        key = hkdf.derive(shared)
+        self.aesgcm = AESGCM(key)
+        self.peer_id = peer_id

--- a/p2papp/storage.py
+++ b/p2papp/storage.py
@@ -1,0 +1,49 @@
+import json
+import os
+from pathlib import Path
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+DATA_DIR = Path(__file__).resolve().parent / 'data'
+TASK_FILE = DATA_DIR / 'tasks.json.enc'
+
+
+def _derive_key(passphrase: bytes) -> bytes:
+    return HKDF(algorithm=SHA256(), length=32, salt=None, info=b'tasks').derive(passphrase)
+
+
+def load_tasks(passphrase: bytes | None = None) -> list[dict]:
+    if not TASK_FILE.exists():
+        return []
+    data = TASK_FILE.read_bytes()
+    if passphrase:
+        aes = AESGCM(_derive_key(passphrase))
+        nonce, ct = data[:12], data[12:]
+        content = aes.decrypt(nonce, ct, None)
+    else:
+        content = data
+    return json.loads(content.decode())
+
+
+def save_tasks(tasks: list[dict], passphrase: bytes | None = None) -> None:
+    DATA_DIR.mkdir(exist_ok=True)
+    encoded = json.dumps(tasks).encode()
+    if passphrase:
+        aes = AESGCM(_derive_key(passphrase))
+        nonce = os.urandom(12)
+        ct = aes.encrypt(nonce, encoded, None)
+        TASK_FILE.write_bytes(nonce + ct)
+    else:
+        TASK_FILE.write_bytes(encoded)
+
+
+def add_task(title: str, description: str, reward: str, radius: int, passphrase: bytes | None = None) -> None:
+    tasks = load_tasks(passphrase)
+    tasks.append({
+        'title': title,
+        'description': description,
+        'reward': reward,
+        'radius': radius,
+    })
+    save_tasks(tasks, passphrase)

--- a/p2papp/wallet.py
+++ b/p2papp/wallet.py
@@ -1,0 +1,42 @@
+import os
+from pathlib import Path
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.hashes import SHA256
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+DATA_DIR = Path(__file__).resolve().parent / 'data'
+WALLET_FILE = DATA_DIR / 'wallet.json.enc'
+
+
+def _derive_key(passphrase: bytes) -> bytes:
+    return HKDF(algorithm=SHA256(), length=32, salt=None, info=b'wallet').derive(passphrase)
+
+
+def generate_wallet(passphrase: bytes | None = None) -> tuple[str, str]:
+    """Generate Bitcoin and Ethereum seeds and store them encrypted."""
+    DATA_DIR.mkdir(exist_ok=True)
+    btc_seed = os.urandom(32).hex()
+    eth_seed = os.urandom(32).hex()
+    if passphrase:
+        key = _derive_key(passphrase)
+        aes = AESGCM(key)
+        nonce = os.urandom(12)
+        data = f'{btc_seed}:{eth_seed}'.encode()
+        ct = aes.encrypt(nonce, data, None)
+        WALLET_FILE.write_bytes(nonce + ct)
+    else:
+        WALLET_FILE.write_text(f'{btc_seed}:{eth_seed}')
+    return btc_seed, eth_seed
+
+
+def load_wallet(passphrase: bytes | None = None) -> tuple[str, str]:
+    data = WALLET_FILE.read_bytes()
+    if passphrase:
+        key = _derive_key(passphrase)
+        aes = AESGCM(key)
+        nonce, ct = data[:12], data[12:]
+        decoded = aes.decrypt(nonce, ct, None).decode()
+    else:
+        decoded = data.decode()
+    btc, eth = decoded.split(':')
+    return btc, eth


### PR DESCRIPTION
## Summary
- implement CLI helpers for pairing, wallet seeds and task storage
- added encrypted JSON storage for tasks and wallets
- update README with new commands and overview

## Testing
- `pip install cryptography websockets`
- `python3 -m p2papp.cli -h`
- `python3 -m p2papp.cli pair`
- `python3 -m p2papp.cli addtask Test "desc" 1ETH 5`
- `python3 -m p2papp.cli listtasks`


------
https://chatgpt.com/codex/tasks/task_e_6848e7de73b083299b6389c3fa976220